### PR TITLE
Migrated orchestrator.go to a more testable format

### DIFF
--- a/internal/server/orchestrator/orchestrator.go
+++ b/internal/server/orchestrator/orchestrator.go
@@ -7,8 +7,6 @@ import (
 	"wildlife/internal/log"
 )
 
-var meta *Orchestrator
-
 type Update struct {
 	Time    time.Time   `json:"time"`
 	State   string      `json:"state"`
@@ -31,7 +29,7 @@ type Orchestrator struct {
 }
 
 // NewOrchestrator initializes a new Orchestrator
-func NewOrchestrator() (*Orchestrator, error) {
+func NewOrchestrator() (meta *Orchestrator, err error) {
 	if meta != nil {
 		return nil, fmt.Errorf("orchestrator has already been initialized")
 	}
@@ -43,7 +41,7 @@ func NewOrchestrator() (*Orchestrator, error) {
 		latest:   map[uuid.UUID]chan Update{},
 	}
 	// Begin listening on channels
-	err := meta.start()
+	err = meta.start()
 	if err != nil {
 		return nil, err
 	}
@@ -83,11 +81,11 @@ func (o *Orchestrator) Close() error {
 }
 
 // Connect accepts incoming pared connections
-func Connect(token uuid.UUID) (chan Update, error) {
-	if meta.latest[token] == nil {
+func (o *Orchestrator) Connect(token uuid.UUID) (chan Update, error) {
+	if o.latest[token] == nil {
 		return nil, fmt.Errorf("token not found")
 	}
-	return meta.latest[token], nil
+	return o.latest[token], nil
 }
 
 // update forwards an update message state to a client

--- a/internal/server/sockets.go
+++ b/internal/server/sockets.go
@@ -41,7 +41,8 @@ func connectWebsockets(writer http.ResponseWriter, request *http.Request) {
 		http.Error(writer, "no token was provided", http.StatusBadRequest)
 		return
 	}
-	rx, err := orchestrator.Connect(uuidParse)
+	orch := request.Context().Value("orch").(*orchestrator.Orchestrator)
+	rx, err := orch.Connect(uuidParse)
 	if err != nil {
 		http.Error(writer, "could not find active job with that token", http.StatusNotFound)
 		return

--- a/internal/server/upload.go
+++ b/internal/server/upload.go
@@ -63,7 +63,9 @@ func uploadFile(writer http.ResponseWriter, request *http.Request) {
 	if err != nil {
 		return
 	}
-	token := orchestrator.NewLeafProcessJob(buf.Bytes())
+	orch := request.Context().Value("orch").(*orchestrator.Orchestrator)
+
+	token := orchestrator.NewLeafProcessJob(orch, buf.Bytes())
 	// Populate the file response struct
 	fileResponse := FileResponse{
 		Name:  m.Filename,

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"wildlife/internal/log"
 	"wildlife/internal/server"
 	"wildlife/internal/server/controller"
-	"wildlife/internal/server/orchestrator"
 	"wildlife/internal/server/tensor"
 )
 
@@ -27,19 +26,6 @@ func main() {
 		log.Errf("Onnx Model initialization failed: %s", err)
 		return
 	}
-
-	var o *orchestrator.Orchestrator
-	o, err = orchestrator.NewOrchestrator()
-	if err != nil {
-		log.Errf("Orchestrator initialization failed: %s", err)
-		return
-	}
-	defer func(o *orchestrator.Orchestrator) {
-		err = o.Close()
-		if err != nil {
-			log.Errf("Orchestrator deconstruction failed: %s", err)
-		}
-	}(o)
 
 	// Initialize the controllers with the database
 	err = controller.InitController()


### PR DESCRIPTION
Migrated orchestrator.go from global initialization to local initialization with a context-based scope injected from the router.